### PR TITLE
Fix GitHub Actions not running on certain branches due to mismatched glob pattern.

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -2,7 +2,7 @@ name: pre-commit
 
 on:
   push:
-    branches: '*'
+    branches: '**'
 
 jobs:
   pre-commit-ubuntu-latest:


### PR DESCRIPTION
Use recursive globstar:
  `branches: '**'` instead of `branches: '*'`.

This allows for matches against branches whose names contain `/`.