### PR TITLE
Fix inconsistent variable name for employee PIN on login page

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -20,10 +20,10 @@
     <div class="login-form-error"></div>
   </div>
   <div class="login-form">
-    <label for="pin">PIN</label>
+    <label for="employee-pin">PIN</label>
     <input
-      id="pin"
-      name="pin"
+      id="employee-pin"
+      name="employee-pin"
       type="password"
       placeholder="Employee PIN"
       title="PIN not entered"


### PR DESCRIPTION
`pin` -> `employee-pin`