### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -1,4 +1,6 @@
 name: pre-commit
+env:
+  SKIP: no-commit-to-branch
 
 on:
   push:


### PR DESCRIPTION
The [no-commit-to-branch](https://github.com/pre-commit/pre-commit-hooks#no-commit-to-branch) hook was recently added (#10) to `pre-commit` which fails if you attempt to commit directly to `main`/`master`. This is a good check to run locally, but merging the PR  that added this hook into `main` caused CI to fail because... it commits directly to `main`. This PR skips `no-commit-to-branch` in GitHub Actions. This fix was tested on `austin/fix_ci` and should fix CI once merged into `main`.